### PR TITLE
Increase timeout for GCS upload

### DIFF
--- a/src/hipChatClient.js
+++ b/src/hipChatClient.js
@@ -18,7 +18,7 @@ export default class HipChatClient extends EventEmitter {
       notify: true,
     };
     this.hipChat.postMessage(params, (error, data) => {
-      if (error) console.log(error);
+      if (error) console.error(error);
       this.emit("posted", data);
     });
   }

--- a/src/messaging-service-client.js
+++ b/src/messaging-service-client.js
@@ -17,27 +17,26 @@ export default class MessagingServiceClient extends EventEmitter {
     });
 
     this.connection.on("open", ()=>{
-      console.log("messaging service connected");
+      console.log(`messaging service connected for ${displayId}`);
       this.emit("connected");
     });
 
     this.connection.on("close", ()=>{
-      console.log("messaging service connection closed");
+      console.log(`messaging service connection closed for ${displayId}`);
       this.emit("closed");
     });
 
     this.connection.on("end", ()=>{
-      console.log("messaging service disconnected");
+      console.log(`messaging service disconnected for ${displayId}`);
       this.emit("disconnected");
     });
 
     this.connection.on("data", (data)=>{
-      console.log("message received", JSON.stringify(data));
       this.emit("data", data);
     });
 
     this.connection.on("error", (error)=>{
-      console.log("messaging error");
+      console.log(`messaging error for ${displayId}`);
       this.emit("error", error);
     });
   }

--- a/src/test-update.js
+++ b/src/test-update.js
@@ -3,7 +3,7 @@ import HipChatClient from "./hipChatClient";
 import verifyToken from "./token/verify-token";
 import Storage from "@google-cloud/storage";
 
-const timeout = 10000;
+const timeout = 30000;
 const logPath = "https://console.cloud.google.com/logs/viewer?project=messaging-service-180514&organizationId=960705295332&minLogLevel=0&expandAll=false&resource=cloud_function%2Ffunction_name%2FmessagingServiceE2E"
 const bucket = "messaging-service-test-bucket";
 const gcsFileName = "test-folder/test-file-for-update.txt";


### PR DESCRIPTION
We get sub-second roundtrip from GCS file modification to pubsub to pubsub controller to messaging service, to websocket connected client.   But it sometimes takes over 15s to upload a 5 byte file to GCS.